### PR TITLE
Allow to change notification per job via annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,25 @@ export DATADOG_ENABLED=true # OPTIONAL DEFAULT false
 export NAMESPACE=KUBERNETES_NAMESPACE # OPTIONAL
 ```
 
+It will take SLACK_CHANNEL as default channel which may be overwritten by SLACK_SUCCEED_CHANNEL, SLACK_FAILED_CHANNEL environment variables.
+
+Another way of overriding behaviour is using job annotations in k8s. Available job annotations to override are: 
+
+```
+- kube-job-notifier/default-channel - will be used as channel for a notification if similar success channel annotation is empty 
+- kube-job-notifier/success-channel - will be used as channel for a success job notification 
+- kube-job-notifier/started-channel - will be used as channel for a started job notification 
+- kube-job-notifier/failed-channel - will be used as channel for a failed job notification 
+```
+
+Also it's possible to suppress notification per job: 
+
+```
+- kube-job-notifier/suppress-success-notification - suppress notification for succesfully finished job even if SLACK_SUCCEEDED_NOTIFY environment variable set to true
+- kube-job-notifier/suppress-started-notification - suppress notification when job is started even if SLACK_STARTED_NOTIFY environment variable set to true 
+- kube-job-notifier/suppress-failed-notification - suppress notification when job is failed even if SLACK_FAILED_NOTIFY environment variable set to true 
+```
+
 ### Event subscription setting(Current Datadog support only)
 - Datadog service checks are sent when the Job succeeds or fails.
 - More information https://docs.datadoghq.com/developers/service_checks/dogstatsd_service_checks_submission/

--- a/controller_test.go
+++ b/controller_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -145,107 +144,4 @@ func addListPodsReactor(fakeClient *fake.Clientset, obj runtime.Object) *fake.Cl
 		return true, obj, nil
 	})
 	return fakeClient
-}
-
-func TestGetSlackChannel(t *testing.T) {
-	tests := []struct {
-		Name              string
-		annotations       map[string]string
-		channelAnnotation string
-		expected          string
-	}{
-		{
-			"No annotations",
-			map[string]string{
-				"kube-job-notifier/foo": "bar",
-			},
-			"kube-job-notifier/success-channel",
-			"",
-		},
-		{
-			"Default channel",
-			map[string]string{
-				"kube-job-notifier/default-channel": "job-alerts",
-			},
-			"kube-job-notifier/success-channel",
-			"job-alerts",
-		},
-		{
-			"Success channel",
-			map[string]string{
-				"kube-job-notifier/default-channel": "job-alerts",
-				"kube-job-notifier/success-channel": "job-alerts-success",
-			},
-			"kube-job-notifier/success-channel",
-			"job-alerts-success",
-		},
-		{
-			"Nil annotation not break",
-			nil,
-			"kube-job-notifier/suppress-success-notification",
-			"",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.Name, func(t *testing.T) {
-			job := &batchv1.Job{}
-			job.Annotations = test.annotations
-
-			result := getSlackChannel(job, test.channelAnnotation)
-
-			assert.Equal(t, test.expected, result)
-		})
-	}
-}
-
-func TestIsNotificationSuppressed(t *testing.T) {
-	tests := []struct {
-		Name                   string
-		annotations            map[string]string
-		suppressAnnotationName string
-		expected               bool
-	}{
-		{
-			"No annotations",
-			map[string]string{
-				"kube-job-notifier/foo": "bar",
-			},
-			"kube-job-notifier/suppress-success-notification",
-			false,
-		},
-		{
-			"Annotation not true",
-			map[string]string{
-				"kube-job-notifier/suppress-success-notification": "false",
-			},
-			"kube-job-notifier/suppress-success-notification",
-			false,
-		},
-		{
-			"Annotation true",
-			map[string]string{
-				"kube-job-notifier/suppress-success-notification": "true",
-			},
-			"kube-job-notifier/suppress-success-notification",
-			true,
-		},
-		{
-			"Nil annotation not break",
-			nil,
-			"kube-job-notifier/suppress-success-notification",
-			false,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.Name, func(t *testing.T) {
-			job := &batchv1.Job{}
-			job.Annotations = test.annotations
-
-			result := isNotificationSuppressed(job, test.suppressAnnotationName)
-
-			assert.Equal(t, test.expected, result)
-		})
-	}
 }

--- a/controller_test.go
+++ b/controller_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/stretchr/testify/assert"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -144,4 +145,95 @@ func addListPodsReactor(fakeClient *fake.Clientset, obj runtime.Object) *fake.Cl
 		return true, obj, nil
 	})
 	return fakeClient
+}
+
+func TestGetSlackChannel(t *testing.T) {
+	tests := []struct {
+		Name              string
+		annotations       map[string]string
+		channelAnnotation string
+		expected          string
+	}{
+		{
+			"No annotations",
+			map[string]string{
+				"kube-job-notifier/foo": "bar",
+			},
+			"kube-job-notifier/success-channel",
+			"",
+		},
+		{
+			"Default channel",
+			map[string]string{
+				"kube-job-notifier/default-channel": "job-alerts",
+			},
+			"kube-job-notifier/success-channel",
+			"job-alerts",
+		},
+		{
+			"Success channel",
+			map[string]string{
+				"kube-job-notifier/default-channel": "job-alerts",
+				"kube-job-notifier/success-channel": "job-alerts-success",
+			},
+			"kube-job-notifier/success-channel",
+			"job-alerts-success",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			job := &batchv1.Job{}
+			job.Annotations = test.annotations
+
+			result := getSlackChannel(job, test.channelAnnotation)
+
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestIsNotificationSuppressed(t *testing.T) {
+	tests := []struct {
+		Name                   string
+		annotations            map[string]string
+		suppressAnnotationName string
+		expected               bool
+	}{
+		{
+			"No annotations",
+			map[string]string{
+				"kube-job-notifier/foo": "bar",
+			},
+			"kube-job-notifier/suppress-success-notification",
+			false,
+		},
+		{
+			"Annotation not true",
+			map[string]string{
+				"kube-job-notifier/suppress-success-notification": "false",
+			},
+			"kube-job-notifier/suppress-success-notification",
+			false,
+		},
+		{
+			"Annotation true",
+			map[string]string{
+				"kube-job-notifier/suppress-success-notification": "true",
+			},
+			"kube-job-notifier/suppress-success-notification",
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			job := &batchv1.Job{}
+			job.Annotations = test.annotations
+
+			result := isNotificationSuppressed(job, test.suppressAnnotationName)
+
+			assert.Equal(t, test.expected, result)
+		})
+	}
 }

--- a/controller_test.go
+++ b/controller_test.go
@@ -179,6 +179,12 @@ func TestGetSlackChannel(t *testing.T) {
 			"kube-job-notifier/success-channel",
 			"job-alerts-success",
 		},
+		{
+			"Nil annotation not break",
+			nil,
+			"kube-job-notifier/suppress-success-notification",
+			"",
+		},
 	}
 
 	for _, test := range tests {
@@ -223,6 +229,12 @@ func TestIsNotificationSuppressed(t *testing.T) {
 			},
 			"kube-job-notifier/suppress-success-notification",
 			true,
+		},
+		{
+			"Nil annotation not break",
+			nil,
+			"kube-job-notifier/suppress-success-notification",
+			false,
 		},
 	}
 

--- a/pkg/notification/notification.go
+++ b/pkg/notification/notification.go
@@ -28,9 +28,9 @@ func (m MessageTemplateParam) calculateExecutionTime() (completionTime *metav1.T
 }
 
 type Notification interface {
-	NotifyStart(messageParam MessageTemplateParam) (err error)
-	NotifySuccess(messageParam MessageTemplateParam) (err error)
-	NotifyFailed(messageParam MessageTemplateParam) (err error)
+	NotifyStart(messageParam MessageTemplateParam, slackChannel string) (err error)
+	NotifySuccess(messageParam MessageTemplateParam, slackChannel string) (err error)
+	NotifyFailed(messageParam MessageTemplateParam, slackChannel string) (err error)
 }
 
 func NewNotifications() map[string]Notification {

--- a/pkg/notification/notification.go
+++ b/pkg/notification/notification.go
@@ -14,6 +14,7 @@ type MessageTemplateParam struct {
 	CompletionTime *metav1.Time
 	ExecutionTime  time.Duration
 	Log            string
+	Annotations    map[string]string
 }
 
 func (m MessageTemplateParam) calculateExecutionTime() (completionTime *metav1.Time, executionTime time.Duration) {
@@ -28,9 +29,9 @@ func (m MessageTemplateParam) calculateExecutionTime() (completionTime *metav1.T
 }
 
 type Notification interface {
-	NotifyStart(messageParam MessageTemplateParam, slackChannel string) (err error)
-	NotifySuccess(messageParam MessageTemplateParam, slackChannel string) (err error)
-	NotifyFailed(messageParam MessageTemplateParam, slackChannel string) (err error)
+	NotifyStart(messageParam MessageTemplateParam) (err error)
+	NotifySuccess(messageParam MessageTemplateParam) (err error)
+	NotifyFailed(messageParam MessageTemplateParam) (err error)
 }
 
 func NewNotifications() map[string]Notification {

--- a/pkg/notification/slack.go
+++ b/pkg/notification/slack.go
@@ -54,7 +54,7 @@ func newSlack() slack {
 
 }
 
-func (s slack) NotifyStart(messageParam MessageTemplateParam) (err error) {
+func (s slack) NotifyStart(messageParam MessageTemplateParam, slackChannel string) (err error) {
 
 	if !isNotifyFromEnv("SLACK_STARTED_NOTIFY") {
 		return nil
@@ -63,6 +63,9 @@ func (s slack) NotifyStart(messageParam MessageTemplateParam) (err error) {
 	succeedChannel := os.Getenv("SLACK_SUCCEED_CHANNEL")
 	if succeedChannel != "" {
 		s.channel = succeedChannel
+	}
+	if slackChannel != "" {
+		s.channel = slackChannel
 	}
 
 	slackMessage, err := getSlackMessage(messageParam)
@@ -97,7 +100,7 @@ func getSlackMessage(messageParam MessageTemplateParam) (slackMessage string, er
 	return b.String(), nil
 }
 
-func (s slack) NotifySuccess(messageParam MessageTemplateParam) (err error) {
+func (s slack) NotifySuccess(messageParam MessageTemplateParam, slackChannel string) (err error) {
 
 	if !isNotifyFromEnv("SLACK_SUCCEEDED_NOTIFY") {
 		return nil
@@ -106,6 +109,9 @@ func (s slack) NotifySuccess(messageParam MessageTemplateParam) (err error) {
 	succeedChannel := os.Getenv("SLACK_SUCCEED_CHANNEL")
 	if succeedChannel != "" {
 		s.channel = succeedChannel
+	}
+	if slackChannel != "" {
+		s.channel = slackChannel
 	}
 	if messageParam.Log != "" {
 		file, err := s.uploadLog(messageParam)
@@ -136,7 +142,7 @@ func (s slack) NotifySuccess(messageParam MessageTemplateParam) (err error) {
 	return nil
 }
 
-func (s slack) NotifyFailed(messageParam MessageTemplateParam) (err error) {
+func (s slack) NotifyFailed(messageParam MessageTemplateParam, slackChannel string) (err error) {
 
 	if !isNotifyFromEnv("SLACK_FAILED_NOTIFY") {
 		return nil
@@ -145,6 +151,9 @@ func (s slack) NotifyFailed(messageParam MessageTemplateParam) (err error) {
 	failedChannel := os.Getenv("SLACK_FAILED_CHANNEL")
 	if failedChannel != "" {
 		s.channel = failedChannel
+	}
+	if slackChannel != "" {
+		s.channel = slackChannel
 	}
 	if messageParam.Log != "" {
 		file, err := s.uploadLog(messageParam)

--- a/pkg/notification/slack_test.go
+++ b/pkg/notification/slack_test.go
@@ -106,3 +106,100 @@ func TestGetSlackMessage(t *testing.T) {
  *Loglink*: Log`
 	assert.Equal(t, expect, actual)
 }
+
+func TestGetSlackChannel(t *testing.T) {
+	tests := []struct {
+		Name              string
+		annotations       map[string]string
+		channelAnnotation string
+		expected          string
+	}{
+		{
+			"No annotations",
+			map[string]string{
+				"kube-job-notifier/foo": "bar",
+			},
+			"kube-job-notifier/success-channel",
+			"",
+		},
+		{
+			"Default channel",
+			map[string]string{
+				"kube-job-notifier/default-channel": "job-alerts",
+			},
+			"kube-job-notifier/success-channel",
+			"job-alerts",
+		},
+		{
+			"Success channel",
+			map[string]string{
+				"kube-job-notifier/default-channel": "job-alerts",
+				"kube-job-notifier/success-channel": "job-alerts-success",
+			},
+			"kube-job-notifier/success-channel",
+			"job-alerts-success",
+		},
+		{
+			"Nil annotation not break",
+			nil,
+			"kube-job-notifier/suppress-success-notification",
+			"",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			result := getSlackChannel(test.annotations, test.channelAnnotation)
+
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestIsNotificationSuppressed(t *testing.T) {
+	tests := []struct {
+		Name                   string
+		annotations            map[string]string
+		suppressAnnotationName string
+		expected               bool
+	}{
+		{
+			"No annotations",
+			map[string]string{
+				"kube-job-notifier/foo": "bar",
+			},
+			"kube-job-notifier/suppress-success-notification",
+			false,
+		},
+		{
+			"Annotation not true",
+			map[string]string{
+				"kube-job-notifier/suppress-success-notification": "false",
+			},
+			"kube-job-notifier/suppress-success-notification",
+			false,
+		},
+		{
+			"Annotation true",
+			map[string]string{
+				"kube-job-notifier/suppress-success-notification": "true",
+			},
+			"kube-job-notifier/suppress-success-notification",
+			true,
+		},
+		{
+			"Nil annotation not break",
+			nil,
+			"kube-job-notifier/suppress-success-notification",
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			result := isNotificationSuppressed(test.annotations, test.suppressAnnotationName)
+
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
# Why

We would like to be able to have a different notification strategy depends on job. 

For example: 
- we would like some job to have notification only in case of failure when for other we would like to have full cycle of notifications (practical use case: we're not really interesting in notifying about success and start of CronJobs because it's running every 5 minutes and effectively flooding into our channel);
- for some job we would like to have notifications go to different channels (practical use case: many teams are hosting their jobs in same cluster under the same namespace and would like to distinguish channels per team which is effectively means distinguish per job). 

# How 

Our proposition is to use job annotations to be able to override default behaviour. I see already some mechanism of overriding default channel (failed and success channel environment variable) so I think it's fitting into existed solution. So, for example for notification on  success job it will take initially SLACK_CHANNEL environment variable to notify then it will try to override with environment variable SLACK_SUCCEED_CHANNEL then it will try to override with value from kube-job-notifier/default-channel annotation then it will try to override it with value from kube-job-notifier/success-channel annotation. 