### PR TITLE
Fix getting annotations for published job

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -31,6 +31,8 @@ const (
 	controllerAgentName = "cronjob-controller"
 	intTrue             = 1
 	searchLabel         = "controller-uid"
+
+	lastAppliedConfigurationKey = "kubectl.kubernetes.io/last-applied-configuration"
 )
 
 var serverStartTime time.Time
@@ -87,12 +89,13 @@ func NewController(
 			if err != nil {
 				klog.Errorf("Get cronjob failed: %v", err)
 			}
+			klog.Infof("Job started: %v", newJob.Status)
 			messageParam := notification.MessageTemplateParam{
 				JobName:     newJob.Name,
 				CronJobName: cronJob,
 				Namespace:   newJob.Namespace,
 				StartTime:   newJob.Status.StartTime,
-				Annotations: newJob.Annotations,
+				Annotations: newJob.Spec.Template.ObjectMeta.Annotations,
 			}
 			for name, n := range notifications {
 				err := n.NotifyStart(messageParam)
@@ -138,7 +141,7 @@ func NewController(
 					StartTime:      newJob.Status.StartTime,
 					CompletionTime: newJob.Status.CompletionTime,
 					Log:            jobLogStr,
-					Annotations:    newJob.Annotations,
+					Annotations:    newJob.Spec.Template.ObjectMeta.Annotations,
 				}
 
 				for name, n := range notifications {
@@ -185,7 +188,7 @@ func NewController(
 					StartTime:      newJob.Status.StartTime,
 					CompletionTime: newJob.Status.CompletionTime,
 					Log:            jobLogStr,
-					Annotations:    newJob.Annotations,
+					Annotations:    newJob.Spec.Template.ObjectMeta.Annotations,
 				}
 				for name, n := range notifications {
 					err := n.NotifyFailed(messageParam)

--- a/pkg/notification/slack.go
+++ b/pkg/notification/slack.go
@@ -63,25 +63,22 @@ func newSlack() slack {
 }
 
 func (s slack) NotifyStart(messageParam MessageTemplateParam) (err error) {
-	klog.Infof("DEBUG: job %s has annotations %v", messageParam.Annotations)
 
 	if !isNotifyFromEnv("SLACK_STARTED_NOTIFY") {
 		return nil
 	}
 
 	if isNotificationSuppressed(messageParam.Annotations, suppressStartedAnnotationName) {
-		klog.Infof("Started notification for %s is suppressed", messageParam.JobName)
+		klog.Infof("Notification for %s is suppressed", messageParam.JobName)
 		return nil
 	}
 
 	succeedChannel := os.Getenv("SLACK_SUCCEED_CHANNEL")
 	if succeedChannel != "" {
-		klog.Infof("Started notification for %s will go to %s channel", messageParam.JobName, succeedChannel)
 		s.channel = succeedChannel
 	}
 	slackChannel := getSlackChannel(messageParam.Annotations, startedAnnotationName)
 	if slackChannel != "" {
-		klog.Infof("Starteed notification for %s will go to %s channel", messageParam.JobName, slackChannel)
 		s.channel = slackChannel
 	}
 
@@ -118,25 +115,22 @@ func getSlackMessage(messageParam MessageTemplateParam) (slackMessage string, er
 }
 
 func (s slack) NotifySuccess(messageParam MessageTemplateParam) (err error) {
-	klog.Infof("DEBUG: job %s has annotations %v", messageParam.Annotations)
 
 	if !isNotifyFromEnv("SLACK_SUCCEEDED_NOTIFY") {
 		return nil
 	}
 
 	if isNotificationSuppressed(messageParam.Annotations, suppressSuccessAnnotationName) {
-		klog.Infof("Success notification for %s is suppressed", messageParam.JobName)
+		klog.Infof("Notification for %s is suppressed", messageParam.JobName)
 		return nil
 	}
 
 	succeedChannel := os.Getenv("SLACK_SUCCEED_CHANNEL")
 	if succeedChannel != "" {
-		klog.Infof("Success notification for %s will go to %s channel", messageParam.JobName, succeedChannel)
 		s.channel = succeedChannel
 	}
 	slackChannel := getSlackChannel(messageParam.Annotations, successAnnotationName)
 	if slackChannel != "" {
-		klog.Infof("Success notification for %s will go to %s channel", messageParam.JobName, slackChannel)
 		s.channel = slackChannel
 	}
 	if messageParam.Log != "" {
@@ -169,25 +163,22 @@ func (s slack) NotifySuccess(messageParam MessageTemplateParam) (err error) {
 }
 
 func (s slack) NotifyFailed(messageParam MessageTemplateParam) (err error) {
-	klog.Infof("DEBUG: job %s has annotations %v", messageParam.Annotations)
 
 	if !isNotifyFromEnv("SLACK_FAILED_NOTIFY") {
 		return nil
 	}
 
 	if isNotificationSuppressed(messageParam.Annotations, suppressFailedAnnotationName) {
-		klog.Infof("Failure notification for %s is suppressed", messageParam.JobName)
+		klog.Infof("Notification for %s is suppressed", messageParam.JobName)
 		return nil
 	}
 
 	failedChannel := os.Getenv("SLACK_FAILED_CHANNEL")
 	if failedChannel != "" {
-		klog.Infof("Failure notification for %s will go to %s channel", messageParam.JobName, failedChannel)
 		s.channel = failedChannel
 	}
 	slackChannel := getSlackChannel(messageParam.Annotations, failedAnnotationName)
 	if slackChannel != "" {
-		klog.Infof("Failure notification for %s will go to %s channel", messageParam.JobName, slackChannel)
 		s.channel = slackChannel
 	}
 	if messageParam.Log != "" {

--- a/pkg/notification/slack.go
+++ b/pkg/notification/slack.go
@@ -63,22 +63,25 @@ func newSlack() slack {
 }
 
 func (s slack) NotifyStart(messageParam MessageTemplateParam) (err error) {
+	klog.Infof("DEBUG: job %s has annotations %v", messageParam.Annotations)
 
 	if !isNotifyFromEnv("SLACK_STARTED_NOTIFY") {
 		return nil
 	}
 
 	if isNotificationSuppressed(messageParam.Annotations, suppressStartedAnnotationName) {
-		klog.Infof("Notification for %s is suppressed", messageParam.JobName)
+		klog.Infof("Started notification for %s is suppressed", messageParam.JobName)
 		return nil
 	}
 
 	succeedChannel := os.Getenv("SLACK_SUCCEED_CHANNEL")
 	if succeedChannel != "" {
+		klog.Infof("Started notification for %s will go to %s channel", messageParam.JobName, succeedChannel)
 		s.channel = succeedChannel
 	}
 	slackChannel := getSlackChannel(messageParam.Annotations, startedAnnotationName)
 	if slackChannel != "" {
+		klog.Infof("Starteed notification for %s will go to %s channel", messageParam.JobName, slackChannel)
 		s.channel = slackChannel
 	}
 
@@ -115,22 +118,25 @@ func getSlackMessage(messageParam MessageTemplateParam) (slackMessage string, er
 }
 
 func (s slack) NotifySuccess(messageParam MessageTemplateParam) (err error) {
+	klog.Infof("DEBUG: job %s has annotations %v", messageParam.Annotations)
 
 	if !isNotifyFromEnv("SLACK_SUCCEEDED_NOTIFY") {
 		return nil
 	}
 
 	if isNotificationSuppressed(messageParam.Annotations, suppressSuccessAnnotationName) {
-		klog.Infof("Notification for %s is suppressed", messageParam.JobName)
+		klog.Infof("Success notification for %s is suppressed", messageParam.JobName)
 		return nil
 	}
 
 	succeedChannel := os.Getenv("SLACK_SUCCEED_CHANNEL")
 	if succeedChannel != "" {
+		klog.Infof("Success notification for %s will go to %s channel", messageParam.JobName, succeedChannel)
 		s.channel = succeedChannel
 	}
 	slackChannel := getSlackChannel(messageParam.Annotations, successAnnotationName)
 	if slackChannel != "" {
+		klog.Infof("Success notification for %s will go to %s channel", messageParam.JobName, slackChannel)
 		s.channel = slackChannel
 	}
 	if messageParam.Log != "" {
@@ -163,22 +169,25 @@ func (s slack) NotifySuccess(messageParam MessageTemplateParam) (err error) {
 }
 
 func (s slack) NotifyFailed(messageParam MessageTemplateParam) (err error) {
+	klog.Infof("DEBUG: job %s has annotations %v", messageParam.Annotations)
 
 	if !isNotifyFromEnv("SLACK_FAILED_NOTIFY") {
 		return nil
 	}
 
 	if isNotificationSuppressed(messageParam.Annotations, suppressFailedAnnotationName) {
-		klog.Infof("Notification for %s is suppressed", messageParam.JobName)
+		klog.Infof("Failure notification for %s is suppressed", messageParam.JobName)
 		return nil
 	}
 
 	failedChannel := os.Getenv("SLACK_FAILED_CHANNEL")
 	if failedChannel != "" {
+		klog.Infof("Failure notification for %s will go to %s channel", messageParam.JobName, failedChannel)
 		s.channel = failedChannel
 	}
 	slackChannel := getSlackChannel(messageParam.Annotations, failedAnnotationName)
 	if slackChannel != "" {
+		klog.Infof("Failure notification for %s will go to %s channel", messageParam.JobName, slackChannel)
 		s.channel = slackChannel
 	}
 	if messageParam.Log != "" {


### PR DESCRIPTION
Made an extra testing and it revealed that in the way how annotations added original PR https://github.com/yutachaos/kube-job-notifier/pull/154 won't work

```
apiVersion: batch/v1
kind: Job
metadata:
  name: global-web-one-off-job-say-hello-example
  namespace: development-dev-1-global-web
  labels:
    app: global-web
spec:
  backoffLimit: 0  # If the Job fails, number of times it retries
  activeDeadlineSeconds: 15 # After this time, all of its running Pods are terminated and the Job status will become Failed
  template:
    metadata:
      annotations:
        kube-job-notifier/default-channel: "yevhen-test-default-notification-channel"
        kube-job-notifier/success-channel: "yevhen-test-success-notification-channel"
        kube-job-notifier/started-channel: "yevhen-test-started-notification-channel"
        kube-job-notifier/suppress-started-notification: "true"
    spec:
      restartPolicy: Never
      containers:
      - name: app
        image: alpine
        command: ["bin/sh", "-c"]
        args:
          - sleep 5;
            echo "hello world, this is the POD log";
            exit 1
        env:
        - name: VAR1
          value: whatever
        - name: VAR2
          value: whatever
        resources:
          limits:
            memory: 512Mi
            cpu: 500m

```