### PR TITLE
Allow to configure from where to take logs for a finished job

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ Also it's possible to suppress notification per job:
 - Datadog service checks are sent when the Job succeeds or fails.
 - More information https://docs.datadoghq.com/developers/service_checks/dogstatsd_service_checks_submission/
 
+### Job with multiple containers logging
+
+By default for cron jobs logs are attached from container with the same name as a cron job. This can be overwritten by adding *kube-job-notifier/log-mode* annotation. 
+
+- *ownerContainer* - get logs only from container with the same name as cron job (default behaviour if annotation is not presented);
+- *podOnly* - get logs from the pod, works perfectly with pod with single container;
+- *podContainers* - get logs from all pod containers and concatenate them. 
+
 ### Run
 
 #### Local

--- a/controller.go
+++ b/controller.go
@@ -221,7 +221,8 @@ func NewController(
 				}
 				notifiedJobs[newJob.Name] = isCompletedJob(kubeclientset, newJob)
 			}
-		}, DeleteFunc: func(obj interface{}) {
+		},
+		DeleteFunc: func(obj interface{}) {
 			deletedJob := obj.(*batchv1.Job)
 			delete(notifiedJobs, deletedJob.Name)
 		},


### PR DESCRIPTION
## What

Added support of configuring the way of getting pod logs

## Why

For some consumers pod container has name which is different from cron job name, in this cases logs attached to slack message will look like this: 

```
container global-web-migration is not valid for pod global-web-migration-27758540-fjlxq
```

Which is effectively is just an error message

## How

Job may have "kube-job-notifier/log-mode" annotation to configure the way of getting pod logs

## Examples

- OwnerContainer in case of CronJob name is not the same as pod container:

```
container global-web-migration is not valid for pod global-web-migration-27758540-fjlxq
```


- PodOnly in case of having single container:
```
secret/ecr-credentials configured
```


- PodContainers with 2 containers: 

```
Container app logs:
container "app" in pod "global-web-migration-27758430-6svbz" is waiting to start: PodInitializing
Container side-container logs:
side container is doing some job and producing non-successful and other messages
```