### PR TITLE
Update Helm chart to version 0.1.14 with latest appVersion v0.0.40

### DIFF
--- a/charts/kube-job-notifier/Chart.yaml
+++ b/charts/kube-job-notifier/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.13
+version: 0.1.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.0.35"
+appVersion: "v0.0.40"
 
 maintainers:
   - name: yutachaos


### PR DESCRIPTION
## Summary
This PR updates the Helm chart to reflect the latest application version.

## Changes
- Updated chart version from `0.1.13` to `0.1.14`
- Updated appVersion from `v0.0.35` to `v0.0.40` (latest release)

## Motivation
The chart was out of sync with the latest application releases. This ensures users can deploy the most recent version of kube-job-notifier.

## Testing
- [x] Chart version incremented correctly
- [x] AppVersion matches the latest git tag