### PR TITLE
improve: add missing tests and fix critical bugs

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/thoas/go-funk"
@@ -70,9 +71,12 @@ func NewController(
 		recorder:   recorder,
 	}
 	serverStartTime = time.Now().Local()
-	notifiedJobs := make(map[string]bool)
+	var notifiedJobs sync.Map
 
-	notifications := notification.NewNotifications()
+	notifications, err := notification.NewNotifications()
+	if err != nil {
+		klog.Fatalf("Error creating notifications: %s", err)
+	}
 	subscriptions := monitoring.NewSubscription()
 	datadogSubscription := subscriptions["datadog"]
 
@@ -101,7 +105,7 @@ func NewController(
 				return
 			}
 
-			if notifiedJobs[newJob.Name] {
+			if v, ok := notifiedJobs.Load(newJob.Name); ok && v.(bool) {
 				return
 			}
 
@@ -128,16 +132,12 @@ func NewController(
 				Annotations: newJob.Spec.Template.Annotations,
 			}
 			for name, n := range notifications {
-				err := n.NotifyStart(messageParam)
-				if err != nil {
+				if err := n.NotifyStart(messageParam); err != nil {
 					klog.Errorf("Failed %s notification: %v", name, err)
 				}
 			}
 
-			// Record that start notification was sent (keep false as completion notification will be sent separately)
-			// Completion notification will be sent in UpdateFunc, so we don't set it here
 			klog.V(4).Infof("Job %s: Start notification sent, waiting for completion", newJob.Name)
-
 		},
 		UpdateFunc: func(old, new any) {
 			newJob := new.(*batchv1.Job)
@@ -145,6 +145,7 @@ func NewController(
 
 			klog.Infof("oldJob.Status:%v", oldJob.Status)
 			klog.Infof("newJob.Status:%v", newJob.Status)
+
 			cronJobName, err := getCronJobNameFromOwnerReferences(kubeclientset, newJob)
 			if err != nil {
 				klog.Errorf("Get cronjob failed: %v", err)
@@ -163,22 +164,23 @@ func NewController(
 				return
 			}
 
-			// Check if status has changed (only notify when succeeded or failed status changes)
 			oldSucceeded := oldJob.Status.Succeeded == intTrue
 			newSucceeded := newJob.Status.Succeeded == intTrue
 			oldFailed := oldJob.Status.Failed == intTrue
 			newFailed := newJob.Status.Failed == intTrue
 
-			// Skip if status hasn't changed
 			if oldSucceeded == newSucceeded && oldFailed == newFailed {
-				klog.V(4).Infof("Job %s: Status unchanged (oldSucceeded=%v, newSucceeded=%v, oldFailed=%v, newFailed=%v), skipping notification",
-					newJob.Name, oldSucceeded, newSucceeded, oldFailed, newFailed)
+				klog.V(4).Infof("Job %s: Status unchanged, skipping notification", newJob.Name)
 				return
 			}
 
-			// Skip if completion notification has already been sent
-			if notifiedJobs[newJob.Name] {
+			if v, ok := notifiedJobs.Load(newJob.Name); ok && v.(bool) {
 				klog.Infof("Job %s: Skipping notification - Already notified", newJob.Name)
+				return
+			}
+
+			// Only proceed for newly succeeded or newly failed
+			if !((newSucceeded && !oldSucceeded) || (newFailed && !oldFailed)) {
 				return
 			}
 
@@ -188,122 +190,65 @@ func NewController(
 				return
 			}
 
-			err = waitForPodRunning(kubeclientset, jobPod)
-			if err != nil {
+			if err = waitForPodRunning(kubeclientset, jobPod); err != nil {
 				klog.Errorf("Error waiting for pod to become running: %v", err)
 				return
 			}
 
-			// Only notify when succeeded status changes (newly succeeded)
-			if newJob.Status.Succeeded == intTrue && !oldSucceeded {
-				klog.Infof("Job succeeded: Name: %s: Status: %v", newJob.Name, newJob.Status)
-				klog.Infof("Job %s: Starting success notification process", newJob.Name)
-				jobPod, err := getPodFromControllerUID(kubeclientset, newJob)
-				if err != nil {
-					klog.Errorf("Get pods failed: %v", err)
-					return
-				}
+			annotations := newJob.Spec.Template.Annotations
+			lm := getLogMode(annotations, logModeAnnotationName)
+			jobLogStr := getJobLogs(kubeclientset, jobPod, cronJobName, lm)
 
-				annotations := newJob.Spec.Template.Annotations
-				lm := getLogMode(annotations, logModeAnnotationName)
-				jobLogStr := getJobLogs(kubeclientset, jobPod, cronJobName, lm)
-
-				messageParam := notification.MessageTemplateParam{
-					JobName:        newJob.Name,
-					CronJobName:    cronJobName,
-					Namespace:      newJob.Namespace,
-					StartTime:      newJob.Status.StartTime,
-					CompletionTime: newJob.Status.CompletionTime,
-					Log:            jobLogStr,
-					Annotations:    annotations,
-				}
-
-				klog.Infof("Job %s: Sending notifications to %d notification services", newJob.Name, len(notifications))
-				for name, n := range notifications {
-					klog.Infof("Job %s: Sending %s notification", newJob.Name, name)
-					err = n.NotifySuccess(messageParam)
-					if err != nil {
-						klog.Errorf("Failed %s notification for job %s: %v", name, newJob.Name, err)
-					} else {
-						klog.Infof("Job %s: %s notification sent successfully", newJob.Name, name)
-					}
-				}
-
-				if os.Getenv("DATADOG_ENABLE") == "true" {
-
-					err = datadogSubscription.SuccessEvent(
-						monitoring.JobInfo{
-							CronJobName: cronJobName,
-							Name:        newJob.Name,
-							Namespace:   newJob.Namespace,
-							Annotations: newJob.Spec.Template.Annotations,
-						})
-					if err != nil {
-						klog.Errorf("Fail event subscribe.: %v", err)
-					}
-				}
-				klog.V(4).Infof("Job succeeded log: %v", jobLogStr)
-				isCompleted := isCompletedJob(kubeclientset, newJob)
-				klog.Infof("Job %s: Setting notified flag to %t", newJob.Name, isCompleted)
-				notifiedJobs[newJob.Name] = isCompleted
-			} else if newJob.Status.Failed == intTrue && !oldFailed {
-				klog.Infof("Job failed: Name: %s: Status: %v", newJob.Name, newJob.Status)
-				klog.Infof("Job %s: Starting failure notification process", newJob.Name)
-				jobPod, err := getPodFromControllerUID(kubeclientset, newJob)
-				if err != nil {
-					klog.Errorf("Get pods failed: %v", err)
-					return
-				}
-
-				cronJobName, err := getCronJobNameFromOwnerReferences(kubeclientset, newJob)
-				if err != nil {
-					klog.Errorf("Get cronjob failed: %v", err)
-					return
-				}
-
-				annotations := newJob.Spec.Template.Annotations
-				lm := getLogMode(annotations, logModeAnnotationName)
-				jobLogStr := getJobLogs(kubeclientset, jobPod, cronJobName, lm)
-
-				messageParam := notification.MessageTemplateParam{
-					JobName:        newJob.Name,
-					CronJobName:    cronJobName,
-					Namespace:      newJob.Namespace,
-					StartTime:      newJob.Status.StartTime,
-					CompletionTime: newJob.Status.CompletionTime,
-					Log:            jobLogStr,
-					Annotations:    annotations,
-				}
-				klog.Infof("Job %s: Sending failure notifications to %d notification services", newJob.Name, len(notifications))
-				for name, n := range notifications {
-					klog.Infof("Job %s: Sending %s failure notification", newJob.Name, name)
-					err := n.NotifyFailed(messageParam)
-					if err != nil {
-						klog.Errorf("Failed %s failure notification for job %s: %v", name, newJob.Name, err)
-					} else {
-						klog.Infof("Job %s: %s failure notification sent successfully", newJob.Name, name)
-					}
-				}
-				if os.Getenv("DATADOG_ENABLE") == "true" {
-					err = datadogSubscription.FailEvent(
-						monitoring.JobInfo{
-							CronJobName: cronJobName,
-							Name:        newJob.Name,
-							Namespace:   newJob.Namespace,
-							Annotations: newJob.Spec.Template.Annotations,
-						})
-					if err != nil {
-						klog.Errorf("Fail event subscribe.: %v", err)
-					}
-				}
-				isCompleted := isCompletedJob(kubeclientset, newJob)
-				klog.Infof("Job %s: Setting failure notified flag to %t", newJob.Name, isCompleted)
-				notifiedJobs[newJob.Name] = isCompleted
+			messageParam := notification.MessageTemplateParam{
+				JobName:        newJob.Name,
+				CronJobName:    cronJobName,
+				Namespace:      newJob.Namespace,
+				StartTime:      newJob.Status.StartTime,
+				CompletionTime: newJob.Status.CompletionTime,
+				Log:            jobLogStr,
+				Annotations:    annotations,
 			}
+
+			jobInfo := monitoring.JobInfo{
+				CronJobName: cronJobName,
+				Name:        newJob.Name,
+				Namespace:   newJob.Namespace,
+				Annotations: newJob.Spec.Template.Annotations,
+			}
+
+			if newSucceeded && !oldSucceeded {
+				klog.Infof("Job succeeded: Name: %s: Status: %v", newJob.Name, newJob.Status)
+				for name, n := range notifications {
+					if err := n.NotifySuccess(messageParam); err != nil {
+						klog.Errorf("Failed %s notification for job %s: %v", name, newJob.Name, err)
+					}
+				}
+				if os.Getenv("DATADOG_ENABLE") == "true" {
+					if err := datadogSubscription.SuccessEvent(jobInfo); err != nil {
+						klog.Errorf("Fail event subscribe.: %v", err)
+					}
+				}
+			} else {
+				klog.Infof("Job failed: Name: %s: Status: %v", newJob.Name, newJob.Status)
+				for name, n := range notifications {
+					if err := n.NotifyFailed(messageParam); err != nil {
+						klog.Errorf("Failed %s failure notification for job %s: %v", name, newJob.Name, err)
+					}
+				}
+				if os.Getenv("DATADOG_ENABLE") == "true" {
+					if err := datadogSubscription.FailEvent(jobInfo); err != nil {
+						klog.Errorf("Fail event subscribe.: %v", err)
+					}
+				}
+			}
+
+			isCompleted := isCompletedJob(kubeclientset, newJob)
+			klog.Infof("Job %s: Setting notified flag to %t", newJob.Name, isCompleted)
+			notifiedJobs.Store(newJob.Name, isCompleted)
 		},
 		DeleteFunc: func(obj any) {
 			deletedJob := obj.(*batchv1.Job)
-			delete(notifiedJobs, deletedJob.Name)
+			notifiedJobs.Delete(deletedJob.Name)
 		},
 	})
 
@@ -371,37 +316,24 @@ func getPodFromControllerUID(kubeclientset kubernetes.Interface, job *batchv1.Jo
 }
 
 func getCronJobNameFromOwnerReferences(kubeclientset kubernetes.Interface, job *batchv1.Job) (cronJobName string, err error) {
-
-	if ownerReferences, ok := funk.Filter(job.OwnerReferences,
+	ownerReferences, ok := funk.Filter(job.OwnerReferences,
 		func(ownerReference metav1.OwnerReference) bool {
 			return ownerReference.Kind == "CronJob"
-		}).([]metav1.OwnerReference); ok &&
-		len(ownerReferences) > 0 {
-		cronJobBeta, err := kubeclientset.BatchV1beta1().CronJobs(job.Namespace).Get(context.TODO(),
-			ownerReferences[0].Name,
-			metav1.GetOptions{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       ownerReferences[0].Kind,
-					APIVersion: ownerReferences[0].APIVersion,
-				},
-			})
+		}).([]metav1.OwnerReference)
+	if !ok || len(ownerReferences) == 0 {
+		return cronJobName, err
+	}
 
-		if err == nil {
-			return cronJobBeta.Name, err
-		}
-
-		cronJobV1, err := kubeclientset.BatchV1().CronJobs(job.Namespace).Get(context.TODO(),
-			ownerReferences[0].Name,
-			metav1.GetOptions{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       ownerReferences[0].Kind,
-					APIVersion: ownerReferences[0].APIVersion,
-				},
-			})
-
-		if err == nil {
-			return cronJobV1.Name, err
-		}
+	cronJobV1, err := kubeclientset.BatchV1().CronJobs(job.Namespace).Get(context.TODO(),
+		ownerReferences[0].Name,
+		metav1.GetOptions{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       ownerReferences[0].Kind,
+				APIVersion: ownerReferences[0].APIVersion,
+			},
+		})
+	if err == nil {
+		return cronJobV1.Name, nil
 	}
 	return cronJobName, err
 }

--- a/controller_test.go
+++ b/controller_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"testing"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -318,4 +319,170 @@ func addListPodsReactor(fakeClient *fake.Clientset, obj runtime.Object) *fake.Cl
 		return true, obj, nil
 	})
 	return fakeClient
+}
+
+func TestGetPodFromControllerUID(t *testing.T) {
+	backoffLimit := int32(0)
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default", UID: "test-uid"},
+		Spec:       batchv1.JobSpec{BackoffLimit: &backoffLimit},
+	}
+
+	t.Run("returns last pod when pods exist", func(t *testing.T) {
+		pods := &v1.PodList{
+			Items: []v1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Labels: map[string]string{searchLabel: "test-uid"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-2", Labels: map[string]string{searchLabel: "test-uid"}}},
+			},
+		}
+		fakeClient := addListPodsReactor(&fake.Clientset{}, pods)
+		got, err := getPodFromControllerUID(fakeClient, job)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Name != "pod-2" {
+			t.Errorf("expected pod-2, got %s", got.Name)
+		}
+	})
+
+	t.Run("returns error when pod list is empty", func(t *testing.T) {
+		pods := &v1.PodList{Items: []v1.Pod{}}
+		fakeClient := addListPodsReactor(&fake.Clientset{}, pods)
+		_, err := getPodFromControllerUID(fakeClient, job)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("returns error on API failure", func(t *testing.T) {
+		fakeClient := &fake.Clientset{}
+		fakeClient.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+			return true, nil, errors.New("api error")
+		})
+		_, err := getPodFromControllerUID(fakeClient, job)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func TestGetCronJobNameFromOwnerReferences(t *testing.T) {
+	t.Run("returns empty string when no owner references", func(t *testing.T) {
+		job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"}}
+		fakeClient := fake.NewSimpleClientset()
+		got, err := getCronJobNameFromOwnerReferences(fakeClient, job)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "" {
+			t.Errorf("expected empty string, got %q", got)
+		}
+	})
+
+	t.Run("returns CronJob name when BatchV1 CronJob exists", func(t *testing.T) {
+		cronJob := &batchv1.CronJob{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-cronjob", Namespace: "default"},
+		}
+		fakeClient := fake.NewSimpleClientset(cronJob)
+		isController := true
+		job := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-cronjob-abc",
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind:       "CronJob",
+						Name:       "my-cronjob",
+						APIVersion: "batch/v1",
+						Controller: &isController,
+					},
+				},
+			},
+		}
+		got, err := getCronJobNameFromOwnerReferences(fakeClient, job)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "my-cronjob" {
+			t.Errorf("expected my-cronjob, got %q", got)
+		}
+	})
+
+	t.Run("returns error when CronJob not found", func(t *testing.T) {
+		fakeClient := fake.NewSimpleClientset()
+		isController := true
+		job := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "missing-cronjob-abc",
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind:       "CronJob",
+						Name:       "missing-cronjob",
+						APIVersion: "batch/v1",
+						Controller: &isController,
+					},
+				},
+			},
+		}
+		got, err := getCronJobNameFromOwnerReferences(fakeClient, job)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if got != "" {
+			t.Errorf("expected empty string on error, got %q", got)
+		}
+	})
+}
+
+func TestWaitForPodRunning(t *testing.T) {
+	t.Run("returns nil when pod is already Running", func(t *testing.T) {
+		pod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+			Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+		}
+		fakeClient := fake.NewSimpleClientset(&pod)
+		err := waitForPodRunning(fakeClient, pod)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("returns nil when pod is Succeeded", func(t *testing.T) {
+		pod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+			Status:     corev1.PodStatus{Phase: corev1.PodSucceeded},
+		}
+		fakeClient := fake.NewSimpleClientset(&pod)
+		err := waitForPodRunning(fakeClient, pod)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("returns nil when pod is Failed", func(t *testing.T) {
+		pod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+			Status:     corev1.PodStatus{Phase: corev1.PodFailed},
+		}
+		fakeClient := fake.NewSimpleClientset(&pod)
+		err := waitForPodRunning(fakeClient, pod)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("returns error when pod get fails", func(t *testing.T) {
+		pod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		}
+		fakeClient := &fake.Clientset{}
+		fakeClient.AddReactor("get", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+			return true, nil, errors.New("api error")
+		})
+		err := waitForPodRunning(fakeClient, pod)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
 }

--- a/main.go
+++ b/main.go
@@ -37,6 +37,9 @@ func main() {
 		}
 	} else {
 		cfg, err := rest.InClusterConfig()
+		if err != nil {
+			klog.Fatalf("Error building in cluster config: %s", err.Error())
+		}
 		kubeClient, err = kubernetes.NewForConfig(cfg)
 		if err != nil {
 			klog.Fatalf("Error building in cluster kubeclient: %s", err.Error())
@@ -63,8 +66,10 @@ func main() {
 }
 
 func init() {
-	u, _ := user.Current()
-	defaultPath := filepath.Join(u.HomeDir, ".kube", "config")
+	defaultPath := ""
+	if u, err := user.Current(); err == nil {
+		defaultPath = filepath.Join(u.HomeDir, ".kube", "config")
+	}
 	// set kubeconfig flag
 	flag.StringVar(&kubeconfig, "kubeconfig", defaultPath, "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")

--- a/pkg/monitoring/subscription.go
+++ b/pkg/monitoring/subscription.go
@@ -1,5 +1,7 @@
 package monitoring
 
+import "os"
+
 type JobInfo struct {
 	Name        string
 	CronJobName string
@@ -22,7 +24,8 @@ type Subscription interface {
 // NewSubscription Support for returning multiple event notifications in one
 func NewSubscription() map[string]Subscription {
 	res := make(map[string]Subscription)
-	// default notification
-	res["datadog"] = newDatadog()
+	if os.Getenv("DATADOG_ENABLE") == "true" {
+		res["datadog"] = newDatadog()
+	}
 	return res
 }

--- a/pkg/notification/msteamsv2.go
+++ b/pkg/notification/msteamsv2.go
@@ -3,6 +3,7 @@ package notification
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"html/template"
 	"io"
 	"net/http"
@@ -64,14 +65,14 @@ type MsTeamsV2 struct {
 	webhookURL string
 }
 
-func newMsTeamsV2() MsTeamsV2 {
+func newMsTeamsV2() (MsTeamsV2, error) {
 	webhookURL := os.Getenv("MSTEAMSV2_WEBHOOK_URL")
 	if webhookURL == "" {
-		panic("please set webhook URL for MSTeamsV2")
+		return MsTeamsV2{}, fmt.Errorf("please set webhook URL for MSTeamsV2")
 	}
 	return MsTeamsV2{
 		webhookURL: webhookURL,
-	}
+	}, nil
 }
 
 func getTeamsMessage(messageParam MessageTemplateParam) (slackMessage string, err error) {
@@ -124,11 +125,13 @@ func (m MsTeamsV2) SendNotification(title string, messageParam MessageTemplatePa
 	body = &payload
 
 	resp, err := http.Post(m.webhookURL, "application/json", body)
-	if resp != nil {
-		klog.Infof("HTTP Response Status: %s", resp.Status)
-	}
 	if err != nil {
 		return err
+	}
+	defer resp.Body.Close()
+	klog.Infof("HTTP Response Status: %s", resp.Status)
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("webhook returned HTTP status %d", resp.StatusCode)
 	}
 	return nil
 }

--- a/pkg/notification/msteamsv2_test.go
+++ b/pkg/notification/msteamsv2_test.go
@@ -227,7 +227,10 @@ func TestMsTeamsV2_NotifyFailed(t *testing.T) {
 }
 
 func TestMsTeamsV2_SendNotificationError(t *testing.T) {
-	msTeams := MsTeamsV2{webhookURL: "http://invalid-url-that-does-not-exist.local"}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	server.Close() // Close immediately so the request fails with connection refused
+
+	msTeams := MsTeamsV2{webhookURL: server.URL}
 
 	messageParam := MessageTemplateParam{
 		JobName:   "test-job",

--- a/pkg/notification/msteamsv2_test.go
+++ b/pkg/notification/msteamsv2_test.go
@@ -17,17 +17,18 @@ func TestNewMsTeamsV2(t *testing.T) {
 	t.Run("should create MsTeamsV2 with webhook URL", func(t *testing.T) {
 		t.Setenv("MSTEAMSV2_WEBHOOK_URL", "https://example.com/webhook")
 
-		msTeams := newMsTeamsV2()
+		msTeams, err := newMsTeamsV2()
 
+		assert.NoError(t, err)
 		assert.Equal(t, "https://example.com/webhook", msTeams.webhookURL)
 	})
 
-	t.Run("should panic when webhook URL is not set", func(t *testing.T) {
+	t.Run("should return error when webhook URL is not set", func(t *testing.T) {
 		t.Setenv("MSTEAMSV2_WEBHOOK_URL", "")
 
-		assert.Panics(t, func() {
-			newMsTeamsV2()
-		})
+		_, err := newMsTeamsV2()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "please set webhook URL for MSTeamsV2")
 	})
 }
 
@@ -253,5 +254,6 @@ func TestMsTeamsV2_SendNotificationWithHTTPError(t *testing.T) {
 
 	err := msTeams.SendNotification("Test", messageParam, colorGreen)
 
-	assert.NoError(t, err) // The function doesn't check HTTP status codes
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
 }

--- a/pkg/notification/notification.go
+++ b/pkg/notification/notification.go
@@ -1,6 +1,7 @@
 package notification
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -36,13 +37,21 @@ type Notification interface {
 	NotifyFailed(messageParam MessageTemplateParam) (err error)
 }
 
-func NewNotifications() map[string]Notification {
+func NewNotifications() (map[string]Notification, error) {
 	res := make(map[string]Notification)
 	if os.Getenv("SLACK_ENABLED") == "true" {
-		res["slack"] = newSlack()
+		s, err := newSlack()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create slack notification: %w", err)
+		}
+		res["slack"] = s
 	}
 	if os.Getenv("MSTEAMSV2_ENABLED") == "true" {
-		res["msteamsv2"] = newMsTeamsV2()
+		m, err := newMsTeamsV2()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create msteamsv2 notification: %w", err)
+		}
+		res["msteamsv2"] = m
 	}
-	return res
+	return res, nil
 }

--- a/pkg/notification/notification_test.go
+++ b/pkg/notification/notification_test.go
@@ -1,12 +1,61 @@
 package notification
 
 import (
+	"os"
+	"testing"
+	"time"
+
 	"github.com/Songmu/flextime"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
-	"time"
 )
+
+func TestNewNotifications(t *testing.T) {
+	t.Run("returns empty map when no env vars set", func(t *testing.T) {
+		os.Unsetenv("SLACK_ENABLED")
+		os.Unsetenv("MSTEAMSV2_ENABLED")
+		notifications, err := NewNotifications()
+		assert.NoError(t, err)
+		assert.Empty(t, notifications)
+	})
+
+	t.Run("returns error when SLACK_ENABLED=true but SLACK_TOKEN missing", func(t *testing.T) {
+		t.Setenv("SLACK_ENABLED", "true")
+		os.Unsetenv("SLACK_TOKEN")
+		_, err := NewNotifications()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "slack")
+	})
+
+	t.Run("includes slack when SLACK_ENABLED=true and SLACK_TOKEN set", func(t *testing.T) {
+		t.Setenv("SLACK_ENABLED", "true")
+		t.Setenv("SLACK_TOKEN", "xoxb-test-token")
+		os.Unsetenv("MSTEAMSV2_ENABLED")
+		notifications, err := NewNotifications()
+		assert.NoError(t, err)
+		assert.Contains(t, notifications, "slack")
+		assert.NotContains(t, notifications, "msteamsv2")
+	})
+
+	t.Run("returns error when MSTEAMSV2_ENABLED=true but webhook URL missing", func(t *testing.T) {
+		os.Unsetenv("SLACK_ENABLED")
+		t.Setenv("MSTEAMSV2_ENABLED", "true")
+		os.Unsetenv("MSTEAMSV2_WEBHOOK_URL")
+		_, err := NewNotifications()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "msteamsv2")
+	})
+
+	t.Run("includes msteamsv2 when MSTEAMSV2_ENABLED=true and webhook URL set", func(t *testing.T) {
+		os.Unsetenv("SLACK_ENABLED")
+		t.Setenv("MSTEAMSV2_ENABLED", "true")
+		t.Setenv("MSTEAMSV2_WEBHOOK_URL", "https://example.com/webhook")
+		notifications, err := NewNotifications()
+		assert.NoError(t, err)
+		assert.Contains(t, notifications, "msteamsv2")
+		assert.NotContains(t, notifications, "slack")
+	})
+}
 
 func TestSetExecutionTime(t *testing.T) {
 	mockTime := time.Date(2020, 11, 28, 1, 2, 3, 123456000, time.UTC)

--- a/pkg/notification/slack.go
+++ b/pkg/notification/slack.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/klog"
 )
 
+
 const (
 	SlackMessageTemplate = `
 {{if .CronJobName}} *CronJobName*: {{.CronJobName}}{{end}}
@@ -50,11 +51,11 @@ type slack struct {
 	username  string
 }
 
-func newSlack() slack {
+func newSlack() (slack, error) {
 	ctx := context.Background()
 	token := os.Getenv("SLACK_TOKEN")
 	if token == "" {
-		panic("please set slack client")
+		return slack{}, fmt.Errorf("please set slack client")
 	}
 
 	newSlack := slackapi.New(token)
@@ -75,7 +76,7 @@ func newSlack() slack {
 	client.username = username
 	client.channel = channel
 
-	return client
+	return client, nil
 }
 
 func (s slack) NotifyStart(messageParam MessageTemplateParam) (err error) {

--- a/pkg/notification/slack.go
+++ b/pkg/notification/slack.go
@@ -322,8 +322,12 @@ func isNotifyFromEnv(key string) bool {
 // getChannelID converts a channel name (e.g., "#channel-name") to a channel ID (e.g., "C1234567890")
 // If the input is already a channel ID or lookup fails, it returns the original value
 func (s slack) getChannelID(ctx context.Context, channel string) string {
+	if channel == "" {
+		return ""
+	}
+
 	// If channel starts with 'C', 'G', or 'D', it's likely already a channel ID
-	if len(channel) > 0 && (channel[0] == 'C' || channel[0] == 'G' || channel[0] == 'D') {
+	if channel[0] == 'C' || channel[0] == 'G' || channel[0] == 'D' {
 		return channel
 	}
 

--- a/pkg/notification/slack_test.go
+++ b/pkg/notification/slack_test.go
@@ -23,14 +23,16 @@ func TestNewSlack(t *testing.T) {
 		channel:  "slack_channel",
 		username: "slack_username",
 	}
-	actual := newSlack()
+	actual, err := newSlack()
+	assert.NoError(t, err)
 	assert.Equal(t, expected.channel, actual.channel)
 	assert.Equal(t, expected.username, actual.username)
 
 	os.Unsetenv("SLACK_CHANNEL")
 	os.Unsetenv("SLACK_USERNAME")
 
-	actual = newSlack()
+	actual, err = newSlack()
+	assert.NoError(t, err)
 	expected = slack{
 		client:   slackapi.New("slack_token"),
 		channel:  "",
@@ -38,15 +40,12 @@ func TestNewSlack(t *testing.T) {
 	}
 	assert.Equal(t, expected.channel, actual.channel)
 	assert.Equal(t, expected.username, actual.username)
-	// For panic test
-	defer func() {
-		err := recover()
-		if err != "please set slack client" {
-			t.Errorf("got %v\nwant %v", err, "please set slack client")
-		}
-	}()
+
+	// Test error when token is not set
 	os.Unsetenv("SLACK_TOKEN")
-	actual = newSlack()
+	_, err = newSlack()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "please set slack client")
 }
 
 func TestNotifyStart(t *testing.T) {

--- a/pkg/notification/slack_test.go
+++ b/pkg/notification/slack_test.go
@@ -15,12 +15,12 @@ import (
 
 func TestNewSlack(t *testing.T) {
 	os.Setenv("SLACK_TOKEN", "slack_token")
-	os.Setenv("SLACK_CHANNEL", "slack_channel")
+	os.Setenv("SLACK_CHANNEL", "C12345678") // channel ID format skips API lookup
 	os.Setenv("SLACK_USERNAME", "slack_username")
 
 	expected := slack{
 		client:   slackapi.New("slack_token"),
-		channel:  "slack_channel",
+		channel:  "C12345678",
 		username: "slack_username",
 	}
 	actual, err := newSlack()


### PR DESCRIPTION
## Summary

- Add tests for previously untested functions (`getPodFromControllerUID`, `getCronJobNameFromOwnerReferences`, `waitForPodRunning`, `NewNotifications`)
- Fix data race on `notifiedJobs` map by switching to `sync.Map`
- Remove deprecated `BatchV1beta1` CronJobs API (removed in K8s 1.25+)
- Fix MS Teams webhook to close response body and return errors on HTTP 4xx/5xx
- Replace `panic()` with proper error returns in `newSlack`/`newMsTeamsV2`/`NewNotifications`
- Only initialize Datadog client when `DATADOG_ENABLE=true`
- Deduplicate `UpdateFunc` by removing redundant pod and cronjob fetches

## Changes

| File | Change |
|------|--------|
| `controller.go` | `sync.Map`, remove `BatchV1beta1`, deduplicate UpdateFunc |
| `controller_test.go` | Add tests for `getPodFromControllerUID`, `getCronJobNameFromOwnerReferences`, `waitForPodRunning` |
| `main.go` | Handle ignored errors from `InClusterConfig` and `user.Current` |
| `pkg/monitoring/subscription.go` | Conditionally initialize Datadog |
| `pkg/notification/msteamsv2.go` | Fix response body leak and HTTP status check |
| `pkg/notification/notification.go` | `NewNotifications` returns error |
| `pkg/notification/slack.go` | `newSlack` returns error instead of panic |
| `*_test.go` | Update tests + add `TestNewNotifications` |

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `go build ./...` passes