### PR TITLE
chore: limit renovate PR flow and enable dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,21 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "packageRules": [
+    {
+      "description": "Group digest updates for SHA-pinned Actions into a single PR",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "digest",
+        "pinDigest"
+      ],
+      "groupName": "github-actions digests"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- Add `config:recommended`, which enables the Dependency Dashboard so a stalled Renovate becomes visible from the repo itself
- Cap PR flow with `prConcurrentLimit: 5` / `prHourlyLimit: 2`
- Group digest updates for SHA-pinned Actions into a single `github-actions digests` PR (11 PRs -> 1)

## Background

Renovate had not opened a PR since 2026-04-11. The cause was `mode=silent` on the Mend-hosted side — the job log shows `Repository is running with mode=silent and will not make Issues or PRs by default`. Silent mode has since been turned off.

The reason this went unnoticed for five months is that `renovate.json` contained only `$schema`: without `config:recommended` the Dependency Dashboard was disabled, so there was no in-repo signal that Renovate had gone quiet. Restoring that signal is the main point of this PR.

Turning silent mode off also means the 24 already-detected updates will all land at once, so the flow limits go in first.

## Test plan

- [ ] Trigger a run from the Mend portal and confirm the Dependency Dashboard issue is created
- [ ] Confirm a single run opens no more than 5 PRs
- [ ] Confirm Actions digest updates are grouped into one `github-actions digests` PR

`renovate-config-validator` (renovate 44) passes locally.