### PR TITLE
fix: add HTTP timeout to MS Teams webhook requests

### DIFF
--- a/pkg/notification/msteamsv2.go
+++ b/pkg/notification/msteamsv2.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"k8s.io/klog"
 )
@@ -17,6 +18,8 @@ const (
 	colorRed   = "Attention"
 	colorGreen = "Good"
 	colorGrey  = "Warning"
+
+	msTeamsRequestTimeout = 10 * time.Second
 
 	TeamsMessageTemplate = `
 {{if .CronJobName}}**CronJobName**: {{.CronJobName}}{{end}}
@@ -63,6 +66,7 @@ type TeamsMessage struct {
 
 type MsTeamsV2 struct {
 	webhookURL string
+	httpClient *http.Client
 }
 
 func newMsTeamsV2() (MsTeamsV2, error) {
@@ -70,9 +74,14 @@ func newMsTeamsV2() (MsTeamsV2, error) {
 	if webhookURL == "" {
 		return MsTeamsV2{}, fmt.Errorf("please set webhook URL for MSTeamsV2")
 	}
+	return newMsTeamsV2WithURL(webhookURL), nil
+}
+
+func newMsTeamsV2WithURL(webhookURL string) MsTeamsV2 {
 	return MsTeamsV2{
 		webhookURL: webhookURL,
-	}, nil
+		httpClient: &http.Client{Timeout: msTeamsRequestTimeout},
+	}
 }
 
 func getTeamsMessage(messageParam MessageTemplateParam) (slackMessage string, err error) {
@@ -124,7 +133,7 @@ func (m MsTeamsV2) SendNotification(title string, messageParam MessageTemplatePa
 
 	body = &payload
 
-	resp, err := http.Post(m.webhookURL, "application/json", body)
+	resp, err := m.httpClient.Post(m.webhookURL, "application/json", body)
 	if err != nil {
 		return err
 	}

--- a/pkg/notification/msteamsv2_test.go
+++ b/pkg/notification/msteamsv2_test.go
@@ -21,6 +21,7 @@ func TestNewMsTeamsV2(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, "https://example.com/webhook", msTeams.webhookURL)
+		assert.Equal(t, msTeamsRequestTimeout, msTeams.httpClient.Timeout)
 	})
 
 	t.Run("should return error when webhook URL is not set", func(t *testing.T) {
@@ -79,7 +80,7 @@ func TestGetTeamsMessageWithoutCronJob(t *testing.T) {
 }
 
 func TestMsTeamsV2_GetTeamsPayload(t *testing.T) {
-	msTeams := MsTeamsV2{webhookURL: "https://example.com/webhook"}
+	msTeams := newMsTeamsV2WithURL("https://example.com/webhook")
 
 	t.Run("should create payload with correct structure", func(t *testing.T) {
 		payload := msTeams.GetTeamsPayload("Test Title", "Test Message", colorGreen)
@@ -146,7 +147,7 @@ func TestMsTeamsV2_NotifyStart(t *testing.T) {
 	}))
 	defer server.Close()
 
-	msTeams := MsTeamsV2{webhookURL: server.URL}
+	msTeams := newMsTeamsV2WithURL(server.URL)
 	startTime := &metav1.Time{Time: mockTime}
 
 	messageParam := MessageTemplateParam{
@@ -175,7 +176,7 @@ func TestMsTeamsV2_NotifySuccess(t *testing.T) {
 	}))
 	defer server.Close()
 
-	msTeams := MsTeamsV2{webhookURL: server.URL}
+	msTeams := newMsTeamsV2WithURL(server.URL)
 	startTime := &metav1.Time{Time: mockTime}
 	completionTime := &metav1.Time{Time: startTime.Add(1 * time.Minute)}
 
@@ -207,7 +208,7 @@ func TestMsTeamsV2_NotifyFailed(t *testing.T) {
 	}))
 	defer server.Close()
 
-	msTeams := MsTeamsV2{webhookURL: server.URL}
+	msTeams := newMsTeamsV2WithURL(server.URL)
 	startTime := &metav1.Time{Time: mockTime}
 	completionTime := &metav1.Time{Time: startTime.Add(1 * time.Minute)}
 
@@ -230,7 +231,7 @@ func TestMsTeamsV2_SendNotificationError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	server.Close() // Close immediately so the request fails with connection refused
 
-	msTeams := MsTeamsV2{webhookURL: server.URL}
+	msTeams := newMsTeamsV2WithURL(server.URL)
 
 	messageParam := MessageTemplateParam{
 		JobName:   "test-job",
@@ -248,7 +249,7 @@ func TestMsTeamsV2_SendNotificationWithHTTPError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	msTeams := MsTeamsV2{webhookURL: server.URL}
+	msTeams := newMsTeamsV2WithURL(server.URL)
 
 	messageParam := MessageTemplateParam{
 		JobName:   "test-job",
@@ -259,4 +260,27 @@ func TestMsTeamsV2_SendNotificationWithHTTPError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "500")
+}
+
+func TestMsTeamsV2_SendNotificationTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	msTeams := MsTeamsV2{
+		webhookURL: server.URL,
+		httpClient: &http.Client{Timeout: 10 * time.Millisecond},
+	}
+
+	messageParam := MessageTemplateParam{
+		JobName:   "test-job",
+		Namespace: "default",
+	}
+
+	err := msTeams.SendNotification("Test", messageParam, colorGreen)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Client.Timeout")
 }


### PR DESCRIPTION
## Summary

- Give `MsTeamsV2` its own `*http.Client` with a 10s timeout instead of using `http.Post` (which uses `http.DefaultClient`, no timeout).
- Add `newMsTeamsV2WithURL` so the client is always configured, and use it in tests.
- Add a test that asserts the request fails when the webhook does not respond in time.

## Background

`http.DefaultClient` has no timeout, so an unresponsive MS Teams webhook could block the notification call — and with it the controller's reconcile loop — indefinitely.

## Routine feedback

None.