### PR TITLE
fix: stop HTML-escaping MS Teams message fields

### DIFF
--- a/pkg/notification/msteamsv2.go
+++ b/pkg/notification/msteamsv2.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"html/template"
+	"text/template"
 	"io"
 	"net/http"
 	"os"

--- a/pkg/notification/msteamsv2_test.go
+++ b/pkg/notification/msteamsv2_test.go
@@ -284,3 +284,18 @@ func TestMsTeamsV2_SendNotificationTimeout(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Client.Timeout")
 }
+
+func TestGetTeamsMessageDoesNotEscapeSpecialCharacters(t *testing.T) {
+	messageParam := MessageTemplateParam{
+		JobName:     "batch's-job & report",
+		CronJobName: "cron<job>",
+		Namespace:   "team's-namespace",
+	}
+
+	message, err := getTeamsMessage(messageParam)
+
+	assert.NoError(t, err)
+	assert.Contains(t, message, "**CronJobName**: cron<job>")
+	assert.Contains(t, message, "**JobName**: batch's-job & report")
+	assert.Contains(t, message, "**Namespace**: team's-namespace")
+}


### PR DESCRIPTION
## Summary

- Use `text/template` instead of `html/template` when rendering the MS Teams message body
- Add a test covering job/cronjob/namespace names containing `&`, `'` and `<>`

## Background

The Teams payload is an Adaptive Card `TextBlock`, which renders Markdown, not HTML, and the JSON encoder already escapes the value. `html/template` therefore only corrupted the output: a job named `batch's-job & report` was delivered to Teams as `batch&#39;s-job &amp; report`.

`pkg/notification/slack.go` has the same `html/template` usage, but Slack does expect `&`, `<` and `>` to be escaped, so that one is left alone here.

## Routine feedback

- `go build` / `go test` inside the default sandbox hung indefinitely on `go: downloading k8s.io/utils ...`; it only completed once re-run with the sandbox disabled. Worth adding to the known pitfalls: if a Go command sits on `downloading` for more than a minute, kill it and re-run without the sandbox.
- `cd "$WORK/repo" && <cmd>` was refused by a path deny-rule because the temp dir could not be resolved up front. Using absolute paths (`git -C "$REPO"`, `sed -i '' "$REPO/file"`) works reliably and is worth recommending in the instructions.
