### PR TITLE
chore: update Helm chart to version 0.1.16 with appVersion v0.0.42

### DIFF
--- a/charts/kube-job-notifier/Chart.yaml
+++ b/charts/kube-job-notifier/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.15
+version: 0.1.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.0.41"
+appVersion: "v0.0.42"
 
 maintainers:
   - name: yutachaos


### PR DESCRIPTION
## Summary

- Bump chart version to `0.1.16`
- Point `appVersion` at the released `v0.0.42` image

Application changes included in `v0.0.42` (since `v0.0.41`):

| PR | Change |
|---|---|
| #292 | Stop HTML-escaping MS Teams message fields |
| #287 | Add HTTP timeout to MS Teams webhook requests |
| #285 | Update `k8s.io/utils` digest |
| #277 | Limit Renovate PR flow and enable dependency dashboard |
| #276 | Pin GitHub Actions to commit SHAs |
| #275 | Add missing tests and fix critical bugs |
