### PR TITLE
docs: align documented Datadog env var and log-mode values with code

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ To obtain a webhook URL, follow the [Microsoft Teams Incoming Webhook documentat
 
 ### Datadog Integration
 
-Set `DATADOG_ENABLED=true` to enable Datadog service check reporting.
+Set `DATADOG_ENABLE=true` to enable Datadog service check reporting.
 
 | Environment Variable | Required | Default | Description |
 |---|---|---|---|
-| `DATADOG_ENABLED` | No | `false` | Enable Datadog service checks |
+| `DATADOG_ENABLE` | No | `false` | Enable Datadog service checks |
 | `DD_TAGS` | No | — | Tags to attach to all service checks (comma-separated) |
 | `DD_NAMESPACE` | No | — | Prefix namespace for metric names |
 
@@ -128,9 +128,9 @@ Set via the `kube-job-notifier/log-mode` annotation on the Job or CronJob resour
 
 | Value | Description |
 |---|---|
-| `ownerContainer` | (default) Collect logs only from the container whose name matches the job name |
-| `podOnly` | Collect logs from the pod as a whole; works well for single-container pods |
-| `podContainers` | Collect logs from all containers in the pod and concatenate them |
+| `OwnerContainer` | (default) Collect logs only from the container whose name matches the job name |
+| `PodOnly` | Collect logs from the pod as a whole; works well for single-container pods |
+| `PodContainers` | Collect logs from all containers in the pod and concatenate them |
 
 ## Running Locally
 

--- a/manifests/sample/deployment.yaml
+++ b/manifests/sample/deployment.yaml
@@ -42,4 +42,4 @@ spec:
             - name: SLACK_FAILED_CHANNEL
               value: "YOUR NOTIFICATION SLACK CHANNEL ID FOR FAILED"
             - name: DATADOG_ENABLE
-              value: true
+              value: "true"


### PR DESCRIPTION
## Summary

- Fix `DATADOG_ENABLED` -> `DATADOG_ENABLE` in the README: `controller.go` and `pkg/monitoring/subscription.go` both read `DATADOG_ENABLE`, so following the README leaves Datadog service checks silently disabled.
- Fix the documented `kube-job-notifier/log-mode` values to match `getLogMode()` in `controller.go`, which matches `OwnerContainer` / `PodOnly` / `PodContainers`. The lowercase values in the README fall through to the default branch, so `podContainers` silently behaved like `OwnerContainer`.
- Quote the boolean `DATADOG_ENABLE` value in `manifests/sample/deployment.yaml`. `env[].value` must be a string, so `kubectl apply -f manifests/sample/` (the install path the README documents) fails on that manifest as-is.

## Background

All three are cases where following the documentation does not produce the documented behaviour. No runtime code is changed.

Noted while reading, not changed here: `NotifyStart` in `pkg/notification/slack.go` applies `SLACK_SUCCEED_CHANNEL` to start notifications, which looks unintentional but would be a behaviour change for existing users.

## Routine feedback

The local `git` global config has `url.git@github.com:.insteadOf https://github.com/`, so both `gh repo clone` and `git clone https://...` were rewritten to SSH and hung/failed for several minutes. Worth adding to the known pitfalls: clone with `GIT_CONFIG_GLOBAL=/dev/null git -c credential.helper='!gh auth git-credential' clone https://github.com/...`, and set `user.name` / `user.email` / the credential helper as local config afterwards. Also, `mktemp -d` under `/var/folders` was not usable here; the session scratchpad dir worked.
