### PR TITLE
fix: include the final retry pod when listing job pods

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -300,7 +300,7 @@ func getPodFromControllerUID(kubeclientset kubernetes.Interface, job *batchv1.Jo
 	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{searchLabel: string(job.UID)}}
 	jobPodList, err := kubeclientset.CoreV1().Pods(job.Namespace).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
-		Limit:         int64(*job.Spec.BackoffLimit),
+		Limit:         int64(*job.Spec.BackoffLimit) + 1,
 	})
 	if err != nil {
 		return corev1.Pod{}, err

--- a/controller_test.go
+++ b/controller_test.go
@@ -364,6 +364,32 @@ func TestGetPodFromControllerUID(t *testing.T) {
 			t.Fatal("expected error, got nil")
 		}
 	})
+
+	t.Run("list limit covers every attempt pod", func(t *testing.T) {
+		retriedBackoffLimit := int32(2)
+		retriedJob := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default", UID: "test-uid"},
+			Spec:       batchv1.JobSpec{BackoffLimit: &retriedBackoffLimit},
+		}
+
+		var gotLimit int64
+		fakeClient := &fake.Clientset{}
+		fakeClient.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+			gotLimit = action.(core.ListActionImpl).ListOptions.Limit
+			return true, &v1.PodList{
+				Items: []v1.Pod{
+					{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Labels: map[string]string{searchLabel: "test-uid"}}},
+				},
+			}, nil
+		})
+
+		if _, err := getPodFromControllerUID(fakeClient, retriedJob); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := int64(retriedBackoffLimit) + 1; gotLimit != want {
+			t.Errorf("expected list limit %d, got %d", want, gotLimit)
+		}
+	})
 }
 
 func TestGetCronJobNameFromOwnerReferences(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix an off-by-one in `getPodFromControllerUID`: pods were listed with `Limit: backoffLimit`, but a Job can create up to `backoffLimit + 1` pods, so on a retried Job the last attempt's pod was truncated from the result and the notification reported the wrong pod's logs.
- Add a regression test asserting the `ListOptions.Limit` sent for the pod lookup.

## Background

`isCompletedJob` in the same file already uses `backoffLimit + 1`; only the pod lookup used the smaller bound. Since `getPodFromControllerUID` returns the *last* item of the list, truncating the list silently selects an earlier attempt — the failure notification then attaches logs from a retry that is not the one that finally failed. With the common `backoffLimit: 0` the bug is invisible, because `Limit: 0` means "no limit" to the API server.

## Routine feedback

- The `go build && go vet && go test` step took ~90s, well past the foreground timeout; backgrounding it and waiting with an `until grep -q '^exit='` loop worked, but chaining a plain `sleep` before `cat` is blocked by the harness — worth adding to the known pitfalls so the next run does not lose a turn to it.
- Worth adding to the repo notes: `gofmt -l .` already reports `pkg/notification/slack.go` and `pkg/notification/msteamsv2.go` as unformatted on `main`, so a `gofmt` check is not a usable signal for whether your own change is clean.
